### PR TITLE
Define `track-color` to improve automation execution path Trace visibility

### DIFF
--- a/src/material_you.yaml
+++ b/src/material_you.yaml
@@ -307,6 +307,7 @@ Material You:
   light-primary-color: hsl(from var(--md-sys-color-primary) h s calc(l + 20))
   divider-color: var(--md-sys-color-surface-container)
   scrollbar-thumb-color: "#2e3038"
+  track-color: var(--md-sys-color-inverse-primary)
 
   # Error
   error-color: var(--md-sys-color-error)

--- a/themes/material_you.yaml
+++ b/themes/material_you.yaml
@@ -248,6 +248,7 @@ Material You:
   light-primary-color: hsl(from var(--md-sys-color-primary) h s calc(l + 20))
   divider-color: var(--md-sys-color-surface-container)
   scrollbar-thumb-color: '#2e3038'
+  track-color: var(--md-sys-color-inverse-primary)
   error-color: var(--md-sys-color-error)
   on-error-color: var(--md-sys-color-on-error)
   primary-background-color: var(--md-sys-color-surface-container)
@@ -476,7 +477,6 @@ Material You:
   bubble-main-background-color: var(--md-sys-color-surface-container-highest)
   bubble-pop-up-main-background-color: var(--md-sys-color-surface-container-low)
   bubble-pop-up-border-radius: var(--md-sys-shape-corner-extra-large)
-  track-color: var(--md-sys-color-inverse-primary)
   version: 4.0.8
 Material You Light:
   md-sys-elevation-level0: none
@@ -615,6 +615,7 @@ Material You Light:
   light-primary-color: hsl(from var(--md-sys-color-primary) h s calc(l + 20))
   divider-color: var(--md-sys-color-surface-container)
   scrollbar-thumb-color: '#2e3038'
+  track-color: var(--md-sys-color-inverse-primary)
   error-color: var(--md-sys-color-error)
   on-error-color: var(--md-sys-color-on-error)
   primary-background-color: var(--md-sys-color-surface-container)
@@ -899,7 +900,6 @@ Material You Light:
   disabled-text-color: 'var(--disabled-text-color-light, #808080)'
   disabled-color: 'var(--disabled-color-light, #a5a5a5)'
   state-inactive-color: 'var(--state-inactive-color-light, #9e9e9e)'
-  track-color: var(--md-sys-color-inverse-primary)
 Material You Dark:
   md-sys-elevation-level0: none
   md-sys-elevation-level1: >-
@@ -1037,6 +1037,7 @@ Material You Dark:
   light-primary-color: hsl(from var(--md-sys-color-primary) h s calc(l + 20))
   divider-color: var(--md-sys-color-surface-container)
   scrollbar-thumb-color: '#2e3038'
+  track-color: var(--md-sys-color-inverse-primary)
   error-color: var(--md-sys-color-error)
   on-error-color: var(--md-sys-color-on-error)
   primary-background-color: var(--md-sys-color-surface-container)
@@ -1321,4 +1322,3 @@ Material You Dark:
   disabled-text-color: 'var(--disabled-text-color-dark, #ffffff80)'
   disabled-color: 'var(--disabled-color-dark, #000000)'
   state-inactive-color: 'var(--state-inactive-color-dark, #484a4e)'
-  track-color: var(--md-sys-color-inverse-primary)

--- a/themes/material_you.yaml
+++ b/themes/material_you.yaml
@@ -476,6 +476,7 @@ Material You:
   bubble-main-background-color: var(--md-sys-color-surface-container-highest)
   bubble-pop-up-main-background-color: var(--md-sys-color-surface-container-low)
   bubble-pop-up-border-radius: var(--md-sys-shape-corner-extra-large)
+  track-color: var(--md-sys-color-inverse-primary)
   version: 4.0.8
 Material You Light:
   md-sys-elevation-level0: none
@@ -898,6 +899,7 @@ Material You Light:
   disabled-text-color: 'var(--disabled-text-color-light, #808080)'
   disabled-color: 'var(--disabled-color-light, #a5a5a5)'
   state-inactive-color: 'var(--state-inactive-color-light, #9e9e9e)'
+  track-color: var(--md-sys-color-inverse-primary)
 Material You Dark:
   md-sys-elevation-level0: none
   md-sys-elevation-level1: >-
@@ -1319,3 +1321,4 @@ Material You Dark:
   disabled-text-color: 'var(--disabled-text-color-dark, #ffffff80)'
   disabled-color: 'var(--disabled-color-dark, #000000)'
   state-inactive-color: 'var(--state-inactive-color-dark, #484a4e)'
+  track-color: var(--md-sys-color-inverse-primary)


### PR DESCRIPTION
## Summary
The  `track-clr` property is used within automation Traces to highlight the paths of the automation that were executed.

This property evaluates `track-color` and falls back to `accent-color`.
Within Material You the `accent-color` is very close to `secondary-text-color` which is used for inactive lines.
This makes it unclear which path executed without clicking on each action in the automation.

In the default theme `accent-color` is very bright (`orange-color` by default) and easy to distinguish.
This commit aims to address this usability issue by defining`track-color` and making use of the `md-sys-color-inverse-primary` colour for the executed paths.

## Screenshots
| Theme | Light | Dark |
|--------|--------|--------|
| **With PR** | ![image](https://github.com/user-attachments/assets/bd942dac-0a60-485e-84ba-5bf7d9947ead) | ![image](https://github.com/user-attachments/assets/5337dd63-1b4c-4ed2-96d1-109d29f69fa6) |
| **Without PR** | ![image](https://github.com/user-attachments/assets/7b922066-b467-450f-837f-e800cd8ec3a3) | ![image](https://github.com/user-attachments/assets/c6538f9e-080b-4f9c-9e29-93fa2ca0279f) |
| **Default** | ![image](https://github.com/user-attachments/assets/4b4fa294-44c2-43c1-a60b-6aed115c8c4e) | ![image](https://github.com/user-attachments/assets/4353c370-c017-4da6-8406-34b9ef3b6828) | 



## Additional Information

The definitions of properties used for the trace line components are outlined below:
```
    --stroke-clr: var(--stroke-color, var(--secondary-text-color));
    --active-clr: var(--active-color, var(--primary-color));
    --track-clr: var(--track-color, var(--accent-color));
    --hover-clr: var(--hover-color, var(--primary-color));
```

Properties `stroke-color`, `active-color`, `track-color` and `hover-color` are currently undefined.